### PR TITLE
Add json validation to improve error handling

### DIFF
--- a/sos-ansible/modules/file_handling.py
+++ b/sos-ansible/modules/file_handling.py
@@ -2,7 +2,7 @@
 Provide all file handling functions
 """
 
-import json
+from json import load, decoder
 import os
 import logging
 import sys
@@ -15,33 +15,38 @@ logger = logging.getLogger(__name__)
 def read_policy(policy_name):
     """Read Rules File and returns its contents"""
     with open(policy_name, "r", encoding="utf-8") as file:
-        data = json.load(file)
-    return data
+        try:
+            data = load(file)
+            return data
+        except decoder.JSONDecodeError as error:
+            logger.error(error)
+            sys.exit(f'Invalid json in {policy_name} file')
 
 
 def validate_tgt_dir(directory):
-    """ Validate if Target Directory exists"""
-    case_dir = os.path.join('/tmp/', directory)
+    """Validate if Target Directory exists"""
+    case_dir = os.path.join("/tmp/", directory)
     if os.path.isdir(case_dir):
-        logging.info("The target directory %s exists. "
-             "Removing it before running the script.", case_dir)
+        logging.info(
+            "The target directory %s exists. ", case_dir + "Removing it before running the script."
+        )
         try:
             rmtree(case_dir)
-        except Exception as error: # pylint: disable=broad-except
+        except Exception as error:  # pylint: disable=broad-except
             logger.error(error)
             sys.exit(1)
 
 
 def create_dir(directory, hostname):
-    """ Create a directory"""
-    case_dir = os.path.join('/tmp/', directory)
+    """Create a directory"""
+    case_dir = os.path.join("/tmp/", directory)
     try:
         if not os.path.isdir(case_dir):
             os.mkdir(case_dir)
     except OSError as error:
         logging.error(error)
         sys.exit(1)
-    final_directory = os.path.join('/tmp/', directory, hostname)
+    final_directory = os.path.join("/tmp/", directory, hostname)
     try:
         if not os.path.isdir(final_directory):
             os.mkdir(final_directory)
@@ -68,7 +73,7 @@ def process_rule(hostname, tgt_dir, rules, file_name, query):
     match_count = 0
 
     if os.path.exists(file_name):
-        with open(file_name, "r", encoding="utf-8") as file:
+        with open(file_name, "r", encoding="utf-8", errors="replace") as file:
             if not query:
                 for lines in file.readlines():
                     data += str(lines)
@@ -80,8 +85,8 @@ def process_rule(hostname, tgt_dir, rules, file_name, query):
                         if reg_rule.findall(lines):
                             data += str(lines)
                             match_count += 1
-                except Exception as error: # pylint: disable=broad-except
-                        logger.error(error)
+                except Exception as error:  # pylint: disable=broad-except
+                    logger.error(error)
     else:
         logging.warning("Skipping %s. Path does not exist.", file_name)
 


### PR DESCRIPTION
adds a layer of error handling around the json file being imported. 

before patch:

```python3 sos-ansible/main.py -d /tmp/case_sosreports -r rules/fake.json
[?] Choose the sos directory: 999999
 > 999999

Traceback (most recent call last):
  File "/Users/user/devel/sos-ansible/sos-ansible/main.py", line 123, in <module>
    main()
  File "/Users/user/devel/sos-ansible/sos-ansible/main.py", line 112, in main
    node_data, curr_policy = data_input(sos_directory, rules_file, user_choice)
  File "/Users/user/devel/sos-ansible/sos-ansible/main.py", line 35, in data_input
    curr_policy = read_policy(rules_file)
  File "/Users/user/devel/sos-ansible/sos-ansible/modules/file_handling.py", line 18, in read_policy
    data = json.load(file)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/json/__init__.py", line 293, in load
    return loads(fp.read(),
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
json.decoder.JSONDecodeError: Expecting ',' delimiter: line 5 column 13 (char 144)
```

after patch:

``` python3 sos-ansible/main.py -d /tmp/case_sosreports -r rules/fake.json
[?] Choose the sos directory: 999999
 > 999999

Invalid json in /Users/user/devel/sos-ansible/rules/fake.json file

```
in sos-ansible.log

```
INFO:Validating rules in place: /Users/gmuniz/devel/sos-ansible/rules/fake.json
ERROR:Expecting ',' delimiter: line 5 column 13 (char 144)
```