### PR TITLE
Add traceback check against controller log files

### DIFF
--- a/rules/rules.json
+++ b/rules/rules.json
@@ -30,7 +30,7 @@
         "path": "",
         "query": "noexec"
     },
-    "tower errors": {
+    "Tower Errors": {
         "files": [
             "callback_receiver.log",
             "dispatcher.log",
@@ -44,6 +44,21 @@
         ],
         "path": "var/log/tower",
         "query": "error"
+    },
+    "Tower Traceback": {
+        "files": [
+            "callback_receiver.log",
+            "dispatcher.log",
+            "job_lifecycle.log",
+            "management_playbooks.log",
+            "task_system.log",
+            "tower.log",
+            "tower_rbac_migrations.log",
+            "tower_system_tracking_migrations.log",
+            "wsbroadcast.log"
+        ],
+        "path": "var/log/tower",
+        "query": "Traceback"
     },
     "OOM": {
         "files": [


### PR DESCRIPTION
It would be helpful to see the amount of "Traceback" messages in the controller's log file. This PR adds a rule to count Traceback messages.
Perhaps it would be better to separate the rule file, but here it is added to the sample rules.

```shell
% sos_ansible -d /tmp/test_sosreport/ -c 99999999
Validating sosreports at the source directory: /tmp/test_sosreport
Validating rules in place: /tmp/rules.json
Processing node 63.56.70.229:
Summary:

63.56.70.229:
--------
Controller Node: True
--------
Tower Info: 0
Instances Capacity: 0
Filesystem: 0
noexec: 19
Tower Errors: 7194
Tower Traceback: 2356   # <==HERE
OOM: 0
Antivirus: 0
Installed Packages: 9
Running Processes: 146
Supervisor: 2
Nginx: 4
Receptor: 1279
LDAP: 1414

Read the matches at /tmp/99999999
SOS_ANSIBLE - END
```
